### PR TITLE
feat(vac): add sentinel branch check in vacuity mode

### DIFF
--- a/seahorn/jobs/string_new_from_string/sea.yaml
+++ b/seahorn/jobs/string_new_from_string/sea.yaml
@@ -1,2 +1,3 @@
 verify_options:
   horn-bv2-word-size: 1
+  horn-bmc-tactic: 'smtfd' 

--- a/seahorn/sea_vac.yaml
+++ b/seahorn/sea_vac.yaml
@@ -9,3 +9,7 @@ verify_options:
   # unwinding assertions
   # Note: checked only by the incremental checking during vacuity
   assert-on-backedge: true
+  # add branch sentinel intrinsic
+  add-branch-sentinel: ''
+  # evaluate branch sentinel intrinsic
+  eval-branch-sentinel: ''


### PR DESCRIPTION
Also change string_from_new_string test to use smtfd tactic since seahorn hangs with default solver. Default solver uses smt solver and smtfd uses sat solver