### PR TITLE
fix(vac): add unroll bound for failing cases

### DIFF
--- a/seahorn/jobs/byte_cursor_compare_lookup/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_compare_lookup/CMakeLists.txt
@@ -5,7 +5,9 @@ add_executable(byte_cursor_compare_lookup
   ${SEA_LIB}/byte_buf_helper.c
   ${SEA_LIB}/bcmp.c
   ${SEA_LIB}/utils.c)
-target_compile_definitions(byte_cursor_compare_lookup PUBLIC MAX_BUFFER_SIZE=10)
+set(MAX_BUFFER_SIZE 10)
+target_compile_definitions(byte_cursor_compare_lookup PUBLIC MAX_BUFFER_SIZE=${MAX_BUFFER_SIZE})
 sea_attach_bc(byte_cursor_compare_lookup)
+configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_compare_lookup)
 

--- a/seahorn/jobs/byte_cursor_compare_lookup/sea.yaml
+++ b/seahorn/jobs/byte_cursor_compare_lookup/sea.yaml
@@ -1,0 +1,2 @@
+verify_options:
+  bound: @MAX_BUFFER_SIZE@

--- a/seahorn/jobs/byte_cursor_eq_c_str/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_eq_c_str/CMakeLists.txt
@@ -5,7 +5,9 @@ add_executable(byte_cursor_eq_c_str
   ${SEA_LIB}/byte_buf_helper.c
   ${SEA_LIB}/bcmp.c
   ${SEA_LIB}/utils.c)
-target_compile_definitions(byte_cursor_eq_c_str PUBLIC MAX_BUFFER_SIZE=10)
+set(MAX_BUFFER_SIZE 10)
+target_compile_definitions(byte_cursor_eq_c_str PUBLIC MAX_BUFFER_SIZE=${MAX_BUFFER_SIZE})
 sea_attach_bc(byte_cursor_eq_c_str)
+configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_eq_c_str)
 

--- a/seahorn/jobs/byte_cursor_eq_c_str/sea.yaml
+++ b/seahorn/jobs/byte_cursor_eq_c_str/sea.yaml
@@ -1,0 +1,2 @@
+verify_options:
+  bound: @MAX_BUFFER_SIZE@

--- a/seahorn/jobs/byte_cursor_eq_c_str_ignore_case/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_eq_c_str_ignore_case/CMakeLists.txt
@@ -5,7 +5,9 @@ add_executable(byte_cursor_eq_c_str_ignore_case
   ${SEA_LIB}/byte_buf_helper.c
   ${SEA_LIB}/bcmp.c
   ${SEA_LIB}/utils.c)
-target_compile_definitions(byte_cursor_eq_c_str_ignore_case PUBLIC MAX_BUFFER_SIZE=10)
+set(MAX_BUFFER_SIZE 10)
+target_compile_definitions(byte_cursor_eq_c_str_ignore_case PUBLIC MAX_BUFFER_SIZE=${MAX_BUFFER_SIZE})
 sea_attach_bc(byte_cursor_eq_c_str_ignore_case)
+configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_eq_c_str_ignore_case)
 

--- a/seahorn/jobs/byte_cursor_eq_c_str_ignore_case/sea.yaml
+++ b/seahorn/jobs/byte_cursor_eq_c_str_ignore_case/sea.yaml
@@ -1,0 +1,2 @@
+verify_options:
+  bound: @MAX_BUFFER_SIZE@

--- a/seahorn/jobs/byte_cursor_eq_ignore_case/CMakeLists.txt
+++ b/seahorn/jobs/byte_cursor_eq_ignore_case/CMakeLists.txt
@@ -5,7 +5,9 @@ add_executable(byte_cursor_eq_ignore_case
   ${SEA_LIB}/byte_buf_helper.c
   ${SEA_LIB}/bcmp.c
   ${SEA_LIB}/utils.c)
-target_compile_definitions(byte_cursor_eq_ignore_case PUBLIC MAX_BUFFER_SIZE=10)
+set(MAX_BUFFER_SIZE 10)
+target_compile_definitions(byte_cursor_eq_ignore_case PUBLIC MAX_BUFFER_SIZE=${MAX_BUFFER_SIZE})
 sea_attach_bc(byte_cursor_eq_ignore_case)
+configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(byte_cursor_eq_ignore_case)
 

--- a/seahorn/jobs/byte_cursor_eq_ignore_case/sea.yaml
+++ b/seahorn/jobs/byte_cursor_eq_ignore_case/sea.yaml
@@ -1,0 +1,2 @@
+verify_options:
+  bound: @MAX_BUFFER_SIZE@


### PR DESCRIPTION
Set --bound=MAX_BUFFER_SIZE for cases failing backward assertions
during vacuity mode.