### PR TITLE
refactor(jobs): migrate remaining linked list jobs to nd helpers

### DIFF
--- a/seahorn/include/linked_list_helper.h
+++ b/seahorn/include/linked_list_helper.h
@@ -42,6 +42,21 @@ void sea_nd_init_aws_linked_list_from_head(struct aws_linked_list *list,
 void sea_nd_init_aws_linked_list_from_tail(struct aws_linked_list *list,
                                            size_t *length);
 
+/*
+    For functions that only access head and tail
+    Non-deterministically initialize aws_linked_list of the forms:
+    If size == 0, then
+    HEAD <--> TAIL
+    If size == 1, then
+    HEAD <--> FRONT <--> TAIL
+    If size == 2, then
+    HEAD <--> FRONT <--> BACK <--> TAIL
+    If size > 2, then
+    HEAD <--> FRONT --> nd_ptr ... nd_ptr <-- BACK <--> TAIL
+*/
+void sea_nd_init_aws_linked_list(struct aws_linked_list *list,
+                                 size_t *length);
+
 // This stores a snapshot of a single linked list node
 struct saved_aws_linked_list_node {
   struct aws_linked_list_node *node;
@@ -55,11 +70,15 @@ struct saved_aws_linked_list {
   size_t saved_size;
   // the node from where to start saving either forwards or backwards
   struct aws_linked_list_node *save_point;
+  // optional save point for saving from both sides
+  struct aws_linked_list_node *save_point_end;
   struct saved_aws_linked_list_node head;
   struct saved_aws_linked_list_node tail;
-  // save upto 3 nodes - head, node1, node2 as needed OR
+  // one direction saves: save upto 3 nodes - head, node1, node2 as needed OR
   // node1, node2, tail as needed
-  struct saved_aws_linked_list_node nodes[3];
+  // bi-direction saves: save up to 4 nodes:
+  // head<->front...back->tail
+  struct saved_aws_linked_list_node nodes[4];
 };
 
 // returns true if the final list is unmodified from start to tail
@@ -79,6 +98,13 @@ bool is_aws_list_unchanged_to_tail(struct aws_linked_list *list,
 bool is_aws_list_unchanged_to_head(struct aws_linked_list *list,
                                    struct saved_aws_linked_list *saved);
 
+// returns true if the final aw_linked_list *list* is unmodified from
+// saved_point to saved_point_end when checking against snapshot
+// *saved*.
+// To be used when *saved* is created using aws_linked_list_save_full
+bool is_aws_list_unchanged_full(struct aws_linked_list *list,
+                                struct saved_aws_linked_list *saved);
+
 // store a snapshot of a sub linked list starting with the node marked
 // 'start'. To be used in when list is created using
 // sea_nd_init_aws_linked_list_from_head(...)
@@ -92,6 +118,13 @@ void aws_linked_list_save_to_tail(struct aws_linked_list *list, size_t size,
 void aws_linked_list_save_to_head(struct aws_linked_list *list, size_t size,
                                   struct aws_linked_list_node *start,
                                   struct saved_aws_linked_list *to_save);
+
+// store full snapshot of *list* to *to_save*; only save 1 level deep from both
+// head and tail, i.e. head.next and tail.prev
+void aws_linked_list_save_full(struct aws_linked_list *list, size_t size,
+                               struct aws_linked_list_node *start,
+                               struct aws_linked_list_node *end,
+                               struct saved_aws_linked_list *to_save);
 
 bool is_aws_linked_list_node_attached_after(
     struct aws_linked_list_node *after, struct aws_linked_list_node *to_attach);

--- a/seahorn/jobs/linked_list_insert_after/CMakeLists.txt
+++ b/seahorn/jobs/linked_list_insert_after/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(linked_list_insert_after
-  aws_linked_list_insert_after_harness.c)
+  aws_linked_list_insert_after_harness.c
+  ${SEA_LIB}/linked_list_helper.c)
 sea_attach_bc(linked_list_insert_after)
 sea_add_unsat_test(linked_list_insert_after)

--- a/seahorn/jobs/linked_list_insert_after/aws_linked_list_insert_after_harness.c
+++ b/seahorn/jobs/linked_list_insert_after/aws_linked_list_insert_after_harness.c
@@ -1,5 +1,6 @@
 #include "seahorn/seahorn.h"
 #include <aws/common/linked_list.h>
+#include <linked_list_helper.h>
 #include "nondet.h"
 
 /*
@@ -20,8 +21,7 @@ int main(void) {
     struct aws_linked_list_node after_next;
     struct aws_linked_list_node to_add;
 
-    after.next = &after_next;
-    after_next.prev = &after;
+    aws_linked_list_attach_after(&after, &after_next, true);
 
     /*
     XZ: ensure after.prev and after_next.next
@@ -37,13 +37,8 @@ int main(void) {
     aws_linked_list_insert_after(&after, &to_add);
 
     /* assertions */
-    sassert(aws_linked_list_node_next_is_valid(&after));
-    sassert(aws_linked_list_node_prev_is_valid(&to_add));
-    sassert(aws_linked_list_node_next_is_valid(&to_add));
-    sassert(aws_linked_list_node_prev_is_valid(&after_next));
-
-    sassert(after.next == &to_add);
-    sassert(after_next.prev == &to_add);
+    sassert(is_aws_linked_list_node_attached_after(&after, &to_add));
+    sassert(is_aws_linked_list_node_attached_after(&to_add, &after_next));
 
     /*
     XZ: ensure after.prev and after_next.next remain unchanged

--- a/seahorn/jobs/linked_list_insert_before/CMakeLists.txt
+++ b/seahorn/jobs/linked_list_insert_before/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(linked_list_insert_before
-  aws_linked_list_insert_before_harness.c)
+  aws_linked_list_insert_before_harness.c
+  ${SEA_LIB}/linked_list_helper.c)
 sea_attach_bc(linked_list_insert_before)
 sea_add_unsat_test(linked_list_insert_before)

--- a/seahorn/jobs/linked_list_insert_before/aws_linked_list_insert_before_harness.c
+++ b/seahorn/jobs/linked_list_insert_before/aws_linked_list_insert_before_harness.c
@@ -1,5 +1,6 @@
 #include "seahorn/seahorn.h"
 #include <aws/common/linked_list.h>
+#include <linked_list_helper.h>
 #include "nondet.h"
 
 /*
@@ -20,8 +21,7 @@ int main(void) {
     struct aws_linked_list_node before_prev;
     struct aws_linked_list_node to_add;
 
-    before.prev = &before_prev;
-    before_prev.next = &before;
+    aws_linked_list_attach_after(&before_prev, &before, true);
 
     /*
     XZ: ensure before.next and before_prev.prev
@@ -37,14 +37,12 @@ int main(void) {
     aws_linked_list_insert_before(&before, &to_add);
 
     /* assertions */
-    sassert(aws_linked_list_node_prev_is_valid(&before));
-    sassert(aws_linked_list_node_prev_is_valid(&to_add));
-    sassert(aws_linked_list_node_next_is_valid(&to_add));
-    sassert(aws_linked_list_node_next_is_valid(&before_prev));
+    sassert(is_aws_linked_list_node_attached_after(&before_prev, &to_add));
+    sassert(is_aws_linked_list_node_attached_after(&to_add, &before));
 
-    sassert(before.prev == &to_add);
-    sassert(before_prev.next == &to_add);
-
+    /*
+    ensure before.next and before_prev.prev remain unchanged
+    */
     sassert(before.next == before_next);
     sassert(before_prev.prev == before_prev_prev);
 }

--- a/seahorn/jobs/linked_list_pop_back/aws_linked_list_pop_back_harness.c
+++ b/seahorn/jobs/linked_list_pop_back/aws_linked_list_pop_back_harness.c
@@ -7,35 +7,27 @@ int main(void) {
   /* data structure */
   struct aws_linked_list list;
   size_t size;
-  // this is the node before/(left-of) the node to be popped.
-  struct aws_linked_list_node *node2;
   sea_nd_init_aws_linked_list_from_tail(&list, &size);
+  struct saved_aws_linked_list to_save = {.saved_size = 0};
   assume(size > 0);
+
   /* Keep the old last node of the linked list */
-  struct aws_linked_list_node *old_prev_last = list.tail.prev->prev;
-  struct aws_linked_list_node *node2_prev_old = list.tail.prev->prev->prev;
-  struct aws_linked_list_node *list_head_next_old = list.head.next;
+  struct aws_linked_list_node *to_pop = list.tail.prev;
+  struct aws_linked_list_node *to_pop_prev = to_pop->prev;
+  aws_linked_list_save_to_head(&list, size, to_pop_prev, &to_save);
 
   /* perform operation under verification */
   struct aws_linked_list_node *ret = aws_linked_list_pop_back(&list);
 
+  /* assertions */
   // -- removed node is detached
-  sassert(ret->next == NULL);
-  sassert(ret->prev == NULL);
-
+  sassert(ret->next == NULL && ret->prev == NULL);
   // -- tail of list is properly updated
-  sassert(list.tail.prev == old_prev_last);
-
+  sassert(is_aws_linked_list_node_attached_after(to_save.save_point, &list.tail));
   // -- list is ok
   sassert(list.head.prev == NULL);
   sassert(list.tail.next == NULL);
-
-  // -- accessible memory is not modified
-  if (size > 1) {
-    sassert(list.head.next == list_head_next_old);
-  } else {
-    sassert(aws_linked_list_empty(&list));
-  }
-  sassert(old_prev_last->prev == node2_prev_old);
+  // -- prev of old popped node til list.head are unchanged
+  sassert(is_aws_list_unchanged_to_head(&list, &to_save));
   return 0;
 }

--- a/seahorn/jobs/linked_list_remove/CMakeLists.txt
+++ b/seahorn/jobs/linked_list_remove/CMakeLists.txt
@@ -1,7 +1,7 @@
 # add head and tail to list size.
 add_executable(linked_list_remove
   aws_linked_list_remove_harness.c
-  ${SEA_LIB}/proof_allocators.c)
+  ${SEA_LIB}/linked_list_helper.c)
 sea_attach_bc(linked_list_remove)
 sea_add_unsat_test(linked_list_remove)
 

--- a/seahorn/jobs/linked_list_remove/aws_linked_list_remove_harness.c
+++ b/seahorn/jobs/linked_list_remove/aws_linked_list_remove_harness.c
@@ -1,5 +1,6 @@
 #include <aws/common/linked_list.h>
 #include "nondet.h"
+#include <linked_list_helper.h>
 #include <seahorn/seahorn.h>
 
 int main(void) {
@@ -11,17 +12,15 @@ int main(void) {
     void* prev_saved_prev;
     void* next_saved_next;
 
-    // -- set prev to nd pointer, which makes it non-dereferencable
+    // -- set prev.prev to nd pointer, which makes it non-dereferencable
     prev_saved_prev = nd_voidp();
-    prev.prev = prev_saved_prev;    
-    prev.next = &node;
+    prev.prev = prev_saved_prev;
 
-    node.prev = &prev;
-    node.next = &next;
+    aws_linked_list_attach_after(&prev, &node, true);
+    aws_linked_list_attach_after(&node, &next, true);
 
-    // -- set next to nd pointer, which makes it non-dereferencable
+    // -- set next.next to nd pointer, which makes it non-dereferencable
     next_saved_next = nd_voidp();
-    next.prev = &node;
     next.next = next_saved_next;
 
 
@@ -29,10 +28,7 @@ int main(void) {
     aws_linked_list_remove(&node);
 
     /* sassertions */
-    sassert(aws_linked_list_node_next_is_valid(&prev));
-    sassert(aws_linked_list_node_prev_is_valid(&next));
-
-    sassert(prev.next == &next);
+    sassert(is_aws_linked_list_node_attached_after(&prev, &next));
 
     // -- check that fields that should be not touched are not changed
     // -- they cannot have been dereferenced because they are loaded with non-deref pointers

--- a/seahorn/jobs/linked_list_swap_contents/CMakeLists.txt
+++ b/seahorn/jobs/linked_list_swap_contents/CMakeLists.txt
@@ -1,6 +1,7 @@
 # add head and tail to list size.
 add_executable(linked_list_swap_contents
-  aws_linked_list_swap_contents_harness.c)
+  aws_linked_list_swap_contents_harness.c
+  ${SEA_LIB}/linked_list_helper.c)
 sea_attach_bc(linked_list_swap_contents)
 sea_add_unsat_test(linked_list_swap_contents)
 

--- a/seahorn/jobs/linked_list_swap_contents/aws_linked_list_swap_contents_harness.c
+++ b/seahorn/jobs/linked_list_swap_contents/aws_linked_list_swap_contents_harness.c
@@ -1,77 +1,20 @@
 #include "nondet.h"
 #include <aws/common/linked_list.h>
+#include <linked_list_helper.h>
 #include <seahorn/seahorn.h>
-
-void sea_nd_init_linked_list(struct aws_linked_list *list, size_t *len) {
-  aws_linked_list_init(list);
-
-  if (nd_bool()) {
-    *len = 0;
-    return;
-  }
-
-  if (nd_bool()) {
-    *len = 1;
-    struct aws_linked_list_node *node;
-    node = malloc(sizeof(struct aws_linked_list_node));
-    assume(node);
-    aws_linked_list_push_front(list, node);
-    return;
-  }
-
-  // -- list of size >1
-  size_t nd_len = nd_size_t();
-  assume(nd_len > 1);
-  *len = nd_len;
-
-  struct aws_linked_list_node *node1;
-  struct aws_linked_list_node *node2;
-
-  node1 = malloc(sizeof(struct aws_linked_list_node));
-  node2 = malloc(sizeof(struct aws_linked_list_node));
-
-  // -- nd_voidp() cannot be derefed, so the list is not accessible
-  // -- except for the first and last elements. This also ensures that 
-  // -- inaccessible elements are not touched by any function that manpulates
-  // -- the linst.
-  list->head.next = node1;
-  node1->prev = &list->head;
-  node1->next = nd_len == 2 ? node2 : nd_voidp();
-
-  node2->prev = nd_len == 2 ? node1 : nd_voidp();
-  node2->next = &list->tail;
-  list->tail.prev = node2;
-}
 
 int main(void) {
   /* data structure */
   struct aws_linked_list a, b;
   size_t a_len, b_len;
+  sea_nd_init_aws_linked_list(&a, &a_len);
+  sea_nd_init_aws_linked_list(&b, &b_len);
 
-  sea_nd_init_linked_list(&a, &a_len);
-  sea_nd_init_linked_list(&b, &b_len);
-
-
-  struct aws_linked_list a_old, b_old;
-  a_old = a;
-  b_old = b;
-
-  void *a_head_next_next_old;
-  void *b_head_next_next_old;
-  void *a_tail_prev_prev_old;
-  void *b_tail_prev_prev_old;
-
-  // -- the first and the last elements of the list are accessible
-  // -- store values that should not be cahnged to compare with later 
-  if (a_len > 0) {
-    a_head_next_next_old = a.head.next->next;
-    a_tail_prev_prev_old = a.tail.prev->prev;
-  }
-  
-  if (b_len > 0) {
-    b_head_next_next_old = b.head.next->next;
-    b_tail_prev_prev_old = b.tail.prev->prev;
-  }
+  /* save old linked lists */
+  struct saved_aws_linked_list saved_a = {.saved_size = 0};
+  struct saved_aws_linked_list saved_b = {.saved_size = 0};
+  aws_linked_list_save_full(&a, a_len, a.head.next, a.tail.prev, &saved_a);
+  aws_linked_list_save_full(&b, b_len, b.head.next, b.tail.prev, &saved_b);
 
   /* perform operation under verification */
   aws_linked_list_swap_contents(&a, &b);
@@ -88,31 +31,9 @@ int main(void) {
   sassert(aws_linked_list_node_next_is_valid(&b.head));
   sassert(aws_linked_list_node_prev_is_valid(&b.tail));
 
-  if (a_len == 0) { 
-    // if a was empty, then b is empty after swap
-    sassert(aws_linked_list_empty(&b));
-  } else {
-    // if a was not empty, b points to the list of a
-    sassert(b.head.next == a_old.head.next);
-    sassert(b.tail.prev == a_old.tail.prev);
-    if (a_len > 1) {
-      // if a had >1 elements, check pointers of first and last element 
-      sassert(b.head.next->next == a_head_next_next_old);
-      sassert(b.tail.prev->prev == a_tail_prev_prev_old);
-    }
-  }
-
-  // -- same check as above but for b
-  if (b_len == 0) {
-    sassert(aws_linked_list_empty(&a));
-  } else {
-    sassert(a.head.next == b_old.head.next);
-    sassert(a.tail.prev == b_old.tail.prev);
-    if (b_len > 1) {
-      sassert(a.head.next->next == b_head_next_next_old);
-      sassert(a.tail.prev->prev == b_tail_prev_prev_old);
-    }
-  }
+  // check b has a's old content, a has b's old content
+  sassert(is_aws_list_unchanged_full(&b, &saved_a));
+  sassert(is_aws_list_unchanged_full(&a, &saved_b));
 
   return 0;
 }


### PR DESCRIPTION
- added helpers for nd aws linked lists with the form head <--> front --> nd...nd <-- back <--> tail
  - `void sea_nd_init_aws_linked_list(struct aws_linked_list *list, size_t *length)` nd initializer function for the above form when length > 2
  -  `void aws_linked_list_save_full(struct aws_linked_list *list, size_t size, struct aws_linked_list_node *start, struct aws_linked_list_node *end, struct saved_aws_linked_list *to_save)` function for saving to `saved_aws_linked_list` snapshot between nodes start and end; `saved_aws_linked_list.start` is not used because there is no need to save more than 1 level; if there is a need to go deeper, user should use `save_to_head` and `save_to_tail` instead.
  - `bool is_aws_list_unchanged_full(struct aws_linked_list *list, struct saved_aws_linked_list *saved)` check entire linkedlist is unchanged between `saved->saved_point` and `saved->saved_point_end`
  - ~~`bool is_aws_list_content_unchanged(struct aws_linked_list *list, struct saved_aws_linked_list *saved)` check contents (nodes excluding head and tail) are unchanged.~~
- migrated rest of linked list jobs to use helpers from #25 