### PR TITLE
Running into error after adding AWS files

### DIFF
--- a/seahorn/jobs/array_eq_c_str/CMakeLists.txt
+++ b/seahorn/jobs/array_eq_c_str/CMakeLists.txt
@@ -1,5 +1,22 @@
 add_executable(array_eq_c_str
   ${AWS_C_COMMON_ROOT}/source/byte_buf.c
+  ${AWS_C_COMMON_ROOT}/source/error.c
+  ${AWS_C_COMMON_ROOT}/source/assert.c
+  ${AWS_C_COMMON_ROOT}/source/common.c
+  ${AWS_C_COMMON_ROOT}/source/array_list.c
+  ${AWS_C_COMMON_ROOT}/source/allocator.c
+  ${AWS_C_COMMON_ROOT}/source/logging.c
+  ${AWS_C_COMMON_ROOT}/source/log_formatter.c
+  ${AWS_C_COMMON_ROOT}/source/log_channel.c
+  ${AWS_C_COMMON_ROOT}/source/log_writer.c
+  ${AWS_C_COMMON_ROOT}/source/string.c
+  ${AWS_C_COMMON_ROOT}/source/date_time.c
+  ${AWS_C_COMMON_ROOT}/source/condition_variable.c
+  ${AWS_C_COMMON_ROOT}/source/posix/system_info.c
+  ${AWS_C_COMMON_ROOT}/source/posix/mutex.c
+  ${AWS_C_COMMON_ROOT}/source/posix/thread.c
+  ${AWS_C_COMMON_ROOT}/source/posix/time.c
+  ${AWS_C_COMMON_ROOT}/source/posix/condition_variable.c
   aws_array_eq_c_str_harness.c
   ${SEA_LIB}/proof_allocators.c
   ${SEA_LIB}/utils.c)
@@ -8,3 +25,5 @@ target_compile_definitions(array_eq_c_str PUBLIC MAX_BUFFER_SIZE=${MAX_BUFFER_SI
 sea_attach_bc(array_eq_c_str)
 configure_file(sea.yaml sea.yaml @ONLY)
 sea_add_unsat_test(array_eq_c_str)
+
+sea_attach_fuzz(array_eq_c_str)


### PR DESCRIPTION
I added a bunch of AWS files to the CMake file of array_eq_c_str to get rid of the undefined errors. I commented out some functions in the aws-c-common to get rid of the duplicated defintions error.

Then I added "${AWS_C_COMMON_ROOT}/source/condition_variable.c" to the CMake file (since it was missing functions), I got this error: 

CMake Error: Attempt to add a custom rule to output "/home/usea/seahorn/verify-c-common/build/seahorn/jobs/array_eq_c_str/llvm-ir/array_eq_c_str.obj/condition_variable.bc.rule" which already has a custom rule.